### PR TITLE
fix: expose TimeProvider for easy usage in unit tests

### DIFF
--- a/examples/SamplePlugin/SamplePlugin.csproj
+++ b/examples/SamplePlugin/SamplePlugin.csproj
@@ -15,7 +15,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/SamplePlugin/SkeletonSample.cs
+++ b/examples/SamplePlugin/SkeletonSample.cs
@@ -56,9 +56,10 @@ namespace SamplePlugin
             // Get the logging facade from the service provider
             var facade = serviceProvider.GetLoggingFacade();
 
-            // access to DateTime constants via provider
-            var now = TimeProvider.GetLocalNow();
-            var utcNow = TimeProvider.GetUtcNow();
+            // access to DateTimeOffset constants via provider
+            var timeProvider = serviceProvider.GetTimeProvider();
+            var now = timeProvider.GetLocalNow();
+            var utcNow = timeProvider.GetUtcNow();
         }
     }
 }

--- a/examples/SamplePlugin/SkeletonSample.cs
+++ b/examples/SamplePlugin/SkeletonSample.cs
@@ -56,7 +56,7 @@ namespace SamplePlugin
             // Get the logging facade from the service provider
             var facade = serviceProvider.GetLoggingFacade();
 
-            // access to DateTimeOffset constants via provider
+            // access to current DateTimeOffset values via provider
             var timeProvider = serviceProvider.GetTimeProvider();
             var now = timeProvider.GetLocalNow();
             var utcNow = timeProvider.GetUtcNow();

--- a/examples/SamplePlugin/SkeletonSample.cs
+++ b/examples/SamplePlugin/SkeletonSample.cs
@@ -4,7 +4,6 @@
 using System;
 using dgt.Model.Dataverse;
 using Digitall.APower;
-using Microsoft.Extensions.Time.Testing;
 using Microsoft.Xrm.Sdk;
 
 namespace SamplePlugin
@@ -60,11 +59,6 @@ namespace SamplePlugin
             // access to DateTime constants via provider
             var now = TimeProvider.GetLocalNow();
             var utcNow = TimeProvider.GetUtcNow();
-
-            TimeProvider = new FakeTimeProvider(new DateTime(2000, 1, 1, 0, 0, 0, 0, DateTimeKind.Local));
-            // access to DateTime constants via provider
-            var nowFaked = TimeProvider.GetLocalNow();
-            var utcNowFaked = TimeProvider.GetUtcNow();
         }
     }
 }

--- a/examples/SamplePlugin/packages.lock.json
+++ b/examples/SamplePlugin/packages.lock.json
@@ -13,15 +13,6 @@
           "System.Text.Json": "8.0.5"
         }
       },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Direct",
-        "requested": "[10.6.0, )",
-        "resolved": "10.6.0",
-        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw==",
-        "dependencies": {
-          "Microsoft.Bcl.TimeProvider": "8.0.1"
-        }
-      },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
         "requested": "[1.0.3, )",

--- a/src/Digitall.APower/Extensions/ServiceProviderExtensions.cs
+++ b/src/Digitall.APower/Extensions/ServiceProviderExtensions.cs
@@ -74,7 +74,8 @@ namespace Digitall.APower
 
         /// <summary>
         /// Retrieves the <see cref="TimeProvider"/> from the service provider.
-        /// It should be used when implementing date-dependent logic and enables unit testing
+        /// It should be used when implementing date-dependent logic and enables unit testing.
+        /// In Dataverse runtime, this falls back to <see cref="TimeProvider.System"/> when no provider is registered.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>The <see cref="TimeProvider"/> instance.</returns>

--- a/src/Digitall.APower/Extensions/ServiceProviderExtensions.cs
+++ b/src/Digitall.APower/Extensions/ServiceProviderExtensions.cs
@@ -15,8 +15,7 @@ namespace Digitall.APower
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>The <see cref="IPluginExecutionContext7" />.</returns>
-        public static IPluginExecutionContext7 GetExecutionContext(this IServiceProvider serviceProvider) =>
-            serviceProvider.Get<IPluginExecutionContext7>();
+        public static IPluginExecutionContext7 GetExecutionContext(this IServiceProvider serviceProvider) => serviceProvider.Get<IPluginExecutionContext7>();
 
         /// <summary>
         /// Retrieves the <see cref="IOrganizationService"/> for the current execution context's user.
@@ -57,8 +56,7 @@ namespace Digitall.APower
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>The <see cref="ITracingService"/>.</returns>
-        public static ITracingService GetTracingService(this IServiceProvider serviceProvider) =>
-            serviceProvider.Get<ITracingService>();
+        public static ITracingService GetTracingService(this IServiceProvider serviceProvider) => serviceProvider.Get<ITracingService>();
 
         /// <summary>
         /// Retrieves the <see cref="ILogger"/> from the service provider.
@@ -73,6 +71,14 @@ namespace Digitall.APower
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>An instance of the <see cref="ISerializerService"/>.</returns>
         public static ISerializerService GetSerializerService(this IServiceProvider serviceProvider) => new SerializerService();
+
+        /// <summary>
+        /// Retrieves the <see cref="TimeProvider"/> from the service provider.
+        /// It should be used when implementing date-dependent logic and enables unit testing
+        /// </summary>
+        /// <param name="serviceProvider">The service provider.</param>
+        /// <returns>The <see cref="TimeProvider"/> instance.</returns>
+        public static TimeProvider GetTimeProvider(this IServiceProvider serviceProvider) => serviceProvider.Get<TimeProvider>() ?? TimeProvider.System;
 
         /// <summary>
         /// Retrieves the <see cref="ILoggingFacade" /> from the service provider.

--- a/src/Digitall.APower/PluginSkeleton.cs
+++ b/src/Digitall.APower/PluginSkeleton.cs
@@ -12,7 +12,7 @@ namespace Digitall.APower
         /// <summary>
         /// Encapsulates access to DateTime to facilitate testing of date-dependent code
         /// </summary>
-        public TimeProvider TimeProvider { get; protected set; } = TimeProvider.System;
+        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
 
         /// <summary>
         /// Executes the plugin using the provided service provider.
@@ -32,8 +32,7 @@ namespace Digitall.APower
                 var executionContext = serviceProvider.GetExecutionContext();
 
                 // Log the start of the execution
-                logger.LogInformation("Execution started {0}: Message {1} - Stage {2} - Mode {3}", GetType().FullName,
-                    executionContext.MessageName, executionContext.GetFormattedExecutionStage(),
+                logger.LogInformation("Execution started {0}: Message {1} - Stage {2} - Mode {3}", GetType().FullName, executionContext.MessageName, executionContext.GetFormattedExecutionStage(),
                     executionContext.GetFormattedExecutionMode());
 
                 // Execute the plugin's internal logic

--- a/src/Digitall.APower/PluginSkeleton.cs
+++ b/src/Digitall.APower/PluginSkeleton.cs
@@ -10,11 +10,6 @@ namespace Digitall.APower
     public abstract class PluginSkeleton : IPlugin
     {
         /// <summary>
-        /// Encapsulates access to DateTime to facilitate testing of date-dependent code
-        /// </summary>
-        public TimeProvider TimeProvider { get; set; } = TimeProvider.System;
-
-        /// <summary>
         /// Executes the plugin using the provided service provider.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>

--- a/tests/Digitall.APower.Tests/packages.lock.json
+++ b/tests/Digitall.APower.Tests/packages.lock.json
@@ -130,14 +130,6 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
-      "Microsoft.Extensions.TimeProvider.Testing": {
-        "type": "Transitive",
-        "resolved": "10.6.0",
-        "contentHash": "qQDiaYWpvIymGbu+kXaMDS8YdqfeQkv6DOxPF2GSwC+eSzIKqOOnSP34TYt7gKqvB7p8/aSptexnW6nF0CUdnw==",
-        "dependencies": {
-          "Microsoft.Bcl.TimeProvider": "8.0.1"
-        }
-      },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "8.0.0",
@@ -310,8 +302,7 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CrmSdk.CoreAssemblies": "[9.0.2.60, )",
-          "Microsoft.Extensions.TimeProvider.Testing": "[10.6.0, )",
-          "dgt.apower": "[1.1.0-beta.4, )"
+          "dgt.apower": "[1.1.0-beta.5, )"
         }
       }
     }


### PR DESCRIPTION
* expose TimeProvider via IServiceProvider, falls back to TimeProvider.System at runtime
* remove FakeTimeProvider usage from sample as its not part of plugin runtime behavior (will be moved to test framework)